### PR TITLE
install: instructions to use tracebox from Docker

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,13 @@ Gregory Detal, Benjamin Hesmans, Olivier Bonaventure, Yves Vanaubel and Benoit D
 <h3>
 <a id="install" class="anchor" href="#install" aria-hidden="true"><span class="octicon octicon-link"></span></a>Install</h3>
 
-<p>Tracebox is available on Mac OS X using <a href="http://brew.sh">Homebrew</a> with <code>brew install tracebox</code>. Yosemite and El Capitan users need to first ensure they installed the full command line developer tools provided by Apple using <code>xcode-select --install</code></p>
+<p>Tracebox is available in <a href="https://hub.docker.com/r/matttbe/tracebox">Docker Hub</a> and can be used like that:</p>
+
+<pre><code>$ docker run -it --rm matttbe/tracebox:latest -h
+$ docker run -it --rm -v "${PWD}:${PWD}" -w "${PWD}" matttbe/tracebox:latest -f my_capture.pcap -p 'IP/tcp{dst=80}/MPCAPABLE/raw("12345678901234567890")' www.multipath-tcp.org
+</code></pre>
+
+<p>Tracebox is also available on Mac OS X using <a href="http://brew.sh">Homebrew</a> with <code>brew install tracebox</code>. Yosemite and El Capitan users need to first ensure they installed the full command line developer tools provided by Apple using <code>xcode-select --install</code></p>
 
 <p>Source can be found at <a href="http://www.github.com/tracebox/tracebox">http://www.github.com/tracebox/tracebox</a>.</p>
 


### PR DESCRIPTION
Tracebox has some issues compiling on recent environments.

Plus it is easier when it is already built.